### PR TITLE
Multiple code improvements - squid:S2447, squid:S1149, squid:S3398

### DIFF
--- a/app/src/main/java/computician/janusclient/EchoTest.java
+++ b/app/src/main/java/computician/janusclient/EchoTest.java
@@ -152,7 +152,7 @@ public class EchoTest {
 
                     @Override
                     public Boolean getTrickle() {
-                        return null;
+                        return Boolean.FALSE;
                     }
 
                     @Override

--- a/app/src/main/java/computician/janusclient/JanusActivity.java
+++ b/app/src/main/java/computician/janusclient/JanusActivity.java
@@ -46,20 +46,21 @@ public class JanusActivity extends Activity {
     private SystemUiHider mSystemUiHider;
 
     private class MyInit implements Runnable {
+
         public void run() {
             init();
         }
-    }
 
-    private void init() {
-        try {
-            EGLContext con = VideoRendererGui.getEGLContext();
-            echoTest = new EchoTest(localRender, remoteRender);
-            echoTest.initializeMediaContext(this, true, true, true, con);
-            echoTest.Start();
+        private void init() {
+            try {
+                EGLContext con = VideoRendererGui.getEGLContext();
+                echoTest = new EchoTest(localRender, remoteRender);
+                echoTest.initializeMediaContext(JanusActivity.this, true, true, true, con);
+                echoTest.Start();
 
-        } catch (Exception ex) {
-            Log.e("computician.janusclient", ex.getMessage());
+            } catch (Exception ex) {
+                Log.e("computician.janusclient", ex.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S2447 - Null should not be returned from a "Boolean" method.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S3398 -  "private" methods called only by inner classes should be moved to those classes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2447
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava
